### PR TITLE
Add missing import of "print_function"

### DIFF
--- a/verhawk/cli/verhawk.py
+++ b/verhawk/cli/verhawk.py
@@ -1,3 +1,5 @@
+from __future__ import print_function
+
 import argparse
 import importlib
 import os


### PR DESCRIPTION
Fixes `SyntaxError` exception under Python 2.x
