### PR TITLE
Add logic to ignore bad modules

### DIFF
--- a/verhawk/scanner.py
+++ b/verhawk/scanner.py
@@ -52,8 +52,10 @@ class Scanner(object):
                         module = None
                         with open(os.devnull, 'w') as devnull:
                             sys.stdout = devnull
-                            module = importer.find_module(modname).load_module(modname)
-
+                            try:
+                                module = importer.find_module(modname).load_module(modname)
+                            except (KeyError, FileNotFoundError):
+                                self.versions[modname] = None
                         sys.stdout = constants.STDOUT
 
                         try:


### PR DESCRIPTION
This additional logic will allow problem modules which do not want to import (like 'jwst.timeconversion') to simply be reported without a version but allow the rest of the modules to be scanned.  It will not cover all potential error cases in a completely general manner, but it at least allows this package to be used with the latest version of the JWST package. 